### PR TITLE
fix(log): avoid panic if no write permission

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -112,19 +112,19 @@ func GetDefaultLogDir() string {
 
 // SetLogger :
 func SetLogger(logDir string, quiet, debug, logJSON bool) {
-	stderrHundler := log15.StderrHandler
+	stderrHandler := log15.StderrHandler
 	logFormat := log15.LogfmtFormat()
 	if logJSON {
 		logFormat = log15.JsonFormatEx(false, true)
-		stderrHundler = log15.StreamHandler(os.Stderr, logFormat)
+		stderrHandler = log15.StreamHandler(os.Stderr, logFormat)
 	}
 
-	lvlHundler := log15.LvlFilterHandler(log15.LvlInfo, stderrHundler)
+	lvlHandler := log15.LvlFilterHandler(log15.LvlInfo, stderrHandler)
 	if debug {
-		lvlHundler = log15.LvlFilterHandler(log15.LvlDebug, stderrHundler)
+		lvlHandler = log15.LvlFilterHandler(log15.LvlDebug, stderrHandler)
 	}
 	if quiet {
-		lvlHundler = log15.LvlFilterHandler(log15.LvlDebug, log15.DiscardHandler())
+		lvlHandler = log15.LvlFilterHandler(log15.LvlDebug, log15.DiscardHandler())
 		pp.SetDefaultOutput(ioutil.Discard)
 	}
 
@@ -133,17 +133,22 @@ func SetLogger(logDir string, quiet, debug, logJSON bool) {
 			log15.Error("Failed to create log directory", "err", err)
 		}
 	}
-	var hundler log15.Handler
+	var handler log15.Handler
 	if _, err := os.Stat(logDir); err == nil {
 		logPath := filepath.Join(logDir, "go-msfdb.log")
-		hundler = log15.MultiHandler(
-			log15.Must.FileHandler(logPath, logFormat),
-			lvlHundler,
-		)
+		if _, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err != nil {
+			log15.Error("Failed to create a log file", "err", err)
+			handler = lvlHandler
+		} else {
+			handler = log15.MultiHandler(
+				log15.Must.FileHandler(logPath, logFormat),
+				lvlHandler,
+			)
+		}
 	} else {
-		hundler = lvlHundler
+		handler = lvlHandler
 	}
-	log15.Root().SetHandler(hundler)
+	log15.Root().SetHandler(handler)
 }
 
 // DeleteNil :


### PR DESCRIPTION
```
 ubuntu@dev  ~│g│s│g│t│go-msfdb  ⎇ master  ./go-msfdb fetch msfdb
panic: open /var/log/go-msfdb/go-msfdb.log: permission denied

goroutine 1 [running]:
github.com/inconshreveable/log15.must(...)
        /home/ubuntu/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20200109203555-b30bc20e4fd1/handler.go:340
github.com/inconshreveable/log15.muster.FileHandler(0xc00024c380, 0x1e, 0xccf140, 0xc36e00, 0x1e, 0x0)
        /home/ubuntu/go/pkg/mod/github.com/inconshreveable/log15@v0.0.0-20200109203555-b30bc20e4fd1/handler.go:348 +0x8d
github.com/takuzoo3868/go-msfdb/utils.SetLogger(0xc0a8d7, 0x11, 0x0)
        /home/ubuntu/go/src/github.com/takuzoo3868/go-msfdb/utils/utils.go:140 +0x232
github.com/takuzoo3868/go-msfdb/commands.initConfig()
        /home/ubuntu/go/src/github.com/takuzoo3868/go-msfdb/commands/root.go:110 +0x187
github.com/spf13/cobra.(*Command).preRun(0x124f160)
        /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:872 +0x49
github.com/spf13/cobra.(*Command).execute(0x124f160, 0x12e3f38, 0x0, 0x0, 0x124f160, 0x12e3f38)
        /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:808 +0x14f
github.com/spf13/cobra.(*Command).ExecuteC(0x124f6a0, 0xc0000201c0, 0x2, 0x2)
        /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
        /home/ubuntu/go/src/github.com/takuzoo3868/go-msfdb/main.go:35 +0x125
 ✗  ubuntu@dev  ~│g│s│g│t│go-msfdb  ⎇ master  ls -alh /var/log/go-msfdb
total 8.0K
drwxr-xr-x  2 root root   4.0K Aug 24 09:23 ./
drwxrwxr-x 16 root syslog 4.0K Aug 24 09:23 ../`
``
