### PR TITLE
fix(redis): change from Hash to Set

### DIFF
--- a/db/redis.go
+++ b/db/redis.go
@@ -15,14 +15,14 @@ import (
 
 /**
 # Redis Data Structure
-- HASH
-  ┌───┬───────────────────────┬────────────┬────────────────┬────────────────────────────────┐
-  │NO │         HASH          │   FIELD    │     VALUE      │            PURPOSE             │
-  └───┴───────────────────────┴────────────┴────────────────┴────────────────────────────────┘
+- SET
+  ┌───┬───────────────────────┬────────────────┬────────────────────────────────┐
+  │NO │          KEY          │     MEMBER     │            PURPOSE             │
+  └───┴───────────────────────┴────────────────┴────────────────────────────────┘
 
-  ┌───┬───────────────────────┬────────────┬────────────────┬────────────────────────────────┐
-  │ 1 │METASPLOIT#C#$CVEID    │$MODULENAME │ $MODULE JSON   │ TO GET MODULE FROM CVEID       │
-  └───┴───────────────────────┴────────────┴────────────────┴────────────────────────────────┘
+  ┌───┬───────────────────────┬────────────────┬────────────────────────────────┐
+  │ 1 │METASPLOIT#C#$CVEID    │ $MODULE JSON   │ TO GET MODULE FROM CVEID       │
+  └───┴───────────────────────┴────────────────┴────────────────────────────────┘
 **/
 
 const (
@@ -99,7 +99,7 @@ func (r *RedisDriver) InsertMetasploit(records []*models.Metasploit) (err error)
 			return fmt.Errorf("Failed to marshal json. err: %s", err)
 		}
 
-		if result := pipe.HSet(ctx, cveIDPrefix+record.CveID, record.Name, string(j)); result.Err() != nil {
+		if result := pipe.SAdd(ctx, cveIDPrefix+record.CveID, string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 		}
 		count++
@@ -117,7 +117,7 @@ func (r *RedisDriver) InsertMetasploit(records []*models.Metasploit) (err error)
 func (r *RedisDriver) GetModuleByCveID(cveID string) []*models.Metasploit {
 	ctx := context.Background()
 	modules := []*models.Metasploit{}
-	results := r.conn.HGetAll(ctx, cveIDPrefix+cveID)
+	results := r.conn.SMembers(ctx, cveIDPrefix+cveID)
 	if results.Err() != nil {
 		log15.Error("Failed to get cve.", "err", results.Err())
 		return nil


### PR DESCRIPTION
Change the data structure of Redis from Hash to Set because the Key and Field will conflict.
In the current implementation, `METASPLOIT#C#$CVEID` is used for Key and `$MODULENAME` is used for Field.
However, look at the following records inserted into the RDB.
If these records were in Redis, the Key and Field would be in conflict.

```console
sqlite> SELECT name, cve_id FROM metasploits WHERE cve_id = "CVE-2020-0796";
name|cve_id
cve_2020_0796_smbghost.rb|CVE-2020-0796
cve_2020_0796_smbghost.rb|CVE-2020-0796
```

Therefore, the Hash type will be dropped and the Set type will be used. Field would have been used for the Hash, but it would not have worked, and by dropping Field and changing to Set, it can be handled without changing the Key.
```
// upstream/master
- HASH
  ┌───┬───────────────────────┬────────────┬────────────────┬────────────────────────────────┐
  │NO │         HASH          │   FIELD    │     VALUE      │            PURPOSE             │
  └───┴───────────────────────┴────────────┴────────────────┴────────────────────────────────┘
  ┌───┬───────────────────────┬────────────┬────────────────┬────────────────────────────────┐
  │ 1 │METASPLOIT#C#$CVEID    │$MODULENAME │ $MODULE JSON   │ TO GET MODULE FROM CVEID       │
  └───┴───────────────────────┴────────────┴────────────────┴────────────────────────────────┘

// PR
- SET
  ┌───┬───────────────────────┬────────────────┬────────────────────────────────┐
  │NO │          KEY          │     MEMBER     │            PURPOSE             │
  └───┴───────────────────────┴────────────────┴────────────────────────────────┘
  ┌───┬───────────────────────┬────────────────┬────────────────────────────────┐
  │ 1 │METASPLOIT#C#$CVEID    │ $MODULE JSON   │ TO GET MODULE FROM CVEID       │
  └───┴───────────────────────┴────────────────┴────────────────────────────────┘
```


# Verification
```console
// upstream/master
$ redis-cli -p 6379
127.0.0.1:6379> HGETALL METASPLOIT#C#CVE-2020-0796
1) "cve_2020_0796_smbghost.rb"
2) "{\"Name\":\"cve_2020_0796_smbghost.rb\",\"Title\":\"SMBv3 Compression Buffer Overflow\",\"Description\":\"A vulnerability exists within the Microsoft Server Message Block 3.1.1 (SMBv3) protocol that can be leveraged to execute code on a vulnerable server. This remove exploit implementation leverages this flaw to execute code in the context of the kernel, finally yielding a session as NT AUTHORITY\\\\SYSTEM in spoolsv.exe. Exploitation can take a few minutes as the necessary data is gathered.\",\"CveID\":\"CVE-2020-0796\",\"References\":[{\"Link\":\"https://ricercasecurity.blogspot.com/2020/04/ill-ask-your-body-smbghost-pre-auth-rce.html\"},{\"Link\":\"https://github.com/chompie1337/SMBGhost_RCE_PoC\"},{\"Link\":\"https://www.youtube.com/watch?v=RSV3f6aEJFY\\u0026t=1865s\"},{\"Link\":\"https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems\"},{\"Link\":\"https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems-part-2-windows\"},{\"Link\":\"https://labs.bluefrostsecurity.de/blog/2017/05/11/windows-10-hals-heap-extinction-of-the-halpinterruptcontroller-table-exploitation-technique/\"},{\"Link\":\"https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb\"}]}"

// PR
$ redis-cli -p 6379
127.0.0.1:6379> SMEMBERS METASPLOIT#C#CVE-2020-0796
1) "{\"Name\":\"cve_2020_0796_smbghost.rb\",\"Title\":\"SMBv3 Compression Buffer Overflow\",\"Description\":\"A vulnerability exists within the Microsoft Server Message Block 3.1.1 (SMBv3) protocol that can be leveraged to execute code on a vulnerable server. This remove exploit implementation leverages this flaw to execute code in the context of the kernel, finally yielding a session as NT AUTHORITY\\\\SYSTEM in spoolsv.exe. Exploitation can take a few minutes as the necessary data is gathered.\",\"CveID\":\"CVE-2020-0796\",\"References\":[{\"Link\":\"https://ricercasecurity.blogspot.com/2020/04/ill-ask-your-body-smbghost-pre-auth-rce.html\"},{\"Link\":\"https://github.com/chompie1337/SMBGhost_RCE_PoC\"},{\"Link\":\"https://www.youtube.com/watch?v=RSV3f6aEJFY\\u0026t=1865s\"},{\"Link\":\"https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems\"},{\"Link\":\"https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems-part-2-windows\"},{\"Link\":\"https://labs.bluefrostsecurity.de/blog/2017/05/11/windows-10-hals-heap-extinction-of-the-halpinterruptcontroller-table-exploitation-technique/\"},{\"Link\":\"https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb\"}]}"
2) "{\"Name\":\"cve_2020_0796_smbghost.rb\",\"Title\":\"SMBv3 Compression Buffer Overflow\",\"Description\":\"A vulnerability exists within the Microsoft Server Message Block 3.1.1 (SMBv3) protocol that can be leveraged to execute code on a vulnerable server. This local exploit implementation leverages this flaw to elevate itself before injecting a payload into winlogon.exe.\",\"CveID\":\"CVE-2020-0796\",\"References\":[{\"Link\":\"https://github.com/danigargu/CVE-2020-0796\"},{\"Link\":\"https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/adv200005\"},{\"Link\":\"https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/cve_2020_0796_smbghost.rb\"}]}"

// upstream/master
$ curl http://127.0.0.1:1327/cves/CVE-2020-0796 | jq
[
  {
    "Name": "cve_2020_0796_smbghost.rb",
    "Title": "SMBv3 Compression Buffer Overflow",
    "Description": "A vulnerability exists within the Microsoft Server Message Block 3.1.1 (SMBv3) protocol that can be leveraged to execute code on a vulnerable server. This remove exploit implementation leverages this flaw to execute code in the context of the kernel, finally yielding a session as NT AUTHORITY\\SYSTEM in spoolsv.exe. Exploitation can take a few minutes as the necessary data is gathered.",
    "CveID": "CVE-2020-0796",
    "References": [
      {
        "Link": "https://ricercasecurity.blogspot.com/2020/04/ill-ask-your-body-smbghost-pre-auth-rce.html"
      },
      {
        "Link": "https://github.com/chompie1337/SMBGhost_RCE_PoC"
      },
      {
        "Link": "https://www.youtube.com/watch?v=RSV3f6aEJFY&t=1865s"
      },
      {
        "Link": "https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems"
      },
      {
        "Link": "https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems-part-2-windows"
      },
      {
        "Link": "https://labs.bluefrostsecurity.de/blog/2017/05/11/windows-10-hals-heap-extinction-of-the-halpinterruptcontroller-table-exploitation-technique/"
      },
      {
        "Link": "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb"
      }
    ]
  }
]

// PR
$ curl http://127.0.0.1:1327/cves/CVE-2020-0796 | jq
[
  {
    "Name": "cve_2020_0796_smbghost.rb",
    "Title": "SMBv3 Compression Buffer Overflow",
    "Description": "A vulnerability exists within the Microsoft Server Message Block 3.1.1 (SMBv3) protocol that can be leveraged to execute code on a vulnerable server. This remove exploit implementation leverages this flaw to execute code in the context of the kernel, finally yielding a session as NT AUTHORITY\\SYSTEM in spoolsv.exe. Exploitation can take a few minutes as the necessary data is gathered.",
    "CveID": "CVE-2020-0796",
    "References": [
      {
        "Link": "https://ricercasecurity.blogspot.com/2020/04/ill-ask-your-body-smbghost-pre-auth-rce.html"
      },
      {
        "Link": "https://github.com/chompie1337/SMBGhost_RCE_PoC"
      },
      {
        "Link": "https://www.youtube.com/watch?v=RSV3f6aEJFY&t=1865s"
      },
      {
        "Link": "https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems"
      },
      {
        "Link": "https://www.coresecurity.com/core-labs/articles/getting-physical-extreme-abuse-of-intel-based-paging-systems-part-2-windows"
      },
      {
        "Link": "https://labs.bluefrostsecurity.de/blog/2017/05/11/windows-10-hals-heap-extinction-of-the-halpinterruptcontroller-table-exploitation-technique/"
      },
      {
        "Link": "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/smb/cve_2020_0796_smbghost.rb"
      }
    ]
  },
  {
    "Name": "cve_2020_0796_smbghost.rb",
    "Title": "SMBv3 Compression Buffer Overflow",
    "Description": "A vulnerability exists within the Microsoft Server Message Block 3.1.1 (SMBv3) protocol that can be leveraged to execute code on a vulnerable server. This local exploit implementation leverages this flaw to elevate itself before injecting a payload into winlogon.exe.",
    "CveID": "CVE-2020-0796",
    "References": [
      {
        "Link": "https://github.com/danigargu/CVE-2020-0796"
      },
      {
        "Link": "https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/adv200005"
      },
      {
        "Link": "https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/local/cve_2020_0796_smbghost.rb"
      }
    ]
  }
]
```

# References
- https://redis.io/commands/sadd : SADD key member
- https://redis.io/commands/smembers :  SMEMBERS key 
- https://pkg.go.dev/github.com/go-redis/redis/v8#StringSliceCmd.Val
- https://redis.io/commands/hset : HSET key field value
- https://redis.io/commands/hgetall :  HGETALL key 
- https://pkg.go.dev/github.com/go-redis/redis/v8#StringStringMapCmd.Val