### PR TITLE
feat(redis): add expire option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Available Commands:
   msfdb       Fetch the data of metasploit-framework cve's list
 
 Flags:
-  -h, --help   help for fetch
+      --expire uint   timeout to set for Redis keys
+  -h, --help          help for fetch
 
 Global Flags:
       --config string       config file (default is $HOME/.go-msfdb.yaml)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Available Commands:
   msfdb       Fetch the data of metasploit-framework cve's list
 
 Flags:
-      --expire uint   timeout to set for Redis keys
+      --expire uint   timeout to set for Redis keys in seconds. If set to 0, the key is persistent.
   -h, --help          help for fetch
 
 Global Flags:

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -15,6 +15,6 @@ var fetchCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(fetchCmd)
 
-	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys in seconds. If set to 0, the key is persistent.")
 	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/commands/fetch.go
+++ b/commands/fetch.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // fetchCmd represents the fetch command
@@ -13,4 +14,7 @@ var fetchCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(fetchCmd)
+
+	fetchCmd.PersistentFlags().Uint("expire", 0, "timeout to set for Redis keys")
+	_ = viper.BindPFlag("expire", fetchCmd.PersistentFlags().Lookup("expire"))
 }

--- a/db/redis.go
+++ b/db/redis.go
@@ -113,15 +113,16 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 			return fmt.Errorf("Failed to marshal json. err: %s", err)
 		}
 
-		if result := pipe.SAdd(ctx, cveIDPrefix+record.CveID, string(j)); result.Err() != nil {
+		key := cveIDPrefix + record.CveID
+		if result := pipe.SAdd(ctx, key, string(j)); result.Err() != nil {
 			return fmt.Errorf("Failed to HSet CVE. err: %s", result.Err())
 		}
 		if expire > 0 {
-			if err := pipe.Expire(ctx, cveIDPrefix+record.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
+			if err := pipe.Expire(ctx, key, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
 		} else {
-			if err := pipe.Persist(ctx, cveIDPrefix+record.CveID).Err(); err != nil {
+			if err := pipe.Persist(ctx, key).Err(); err != nil {
 				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
 			}
 		}

--- a/db/redis.go
+++ b/db/redis.go
@@ -120,6 +120,10 @@ func (r *RedisDriver) InsertMetasploit(records []models.Metasploit) (err error) 
 			if err := pipe.Expire(ctx, cveIDPrefix+record.CveID, time.Duration(expire*uint(time.Second))).Err(); err != nil {
 				return fmt.Errorf("Failed to set Expire to Key. err: %s", err)
 			}
+		} else {
+			if err := pipe.Persist(ctx, cveIDPrefix+record.CveID).Err(); err != nil {
+				return fmt.Errorf("Failed to remove the existing timeout on Key. err: %s", err)
+			}
 		}
 
 		if _, err = pipe.Exec(ctx); err != nil {


### PR DESCRIPTION
Unlike RDBs, Redis does not lose old data. For users who do not want to be affected by old data remaining, it is possible to set a timeout deadline for keys using the Redis EXPIRE command.

# How Has This Been Tested?
```console
$ redis-cli -p 6379
127.0.0.1:6379> TTL "METASPLOIT#C#CVE-2009-1430"
(integer) 74
127.0.0.1:6379> keys METASPLOIT#C#*
(empty array)
```

# Reference
- https://redis.io/commands/expire